### PR TITLE
make array index lookup 2-3x faster

### DIFF
--- a/src/Record.php
+++ b/src/Record.php
@@ -115,8 +115,10 @@ abstract readonly class Record
 			if ($key !== false) {
 				unset($ids[$type][$key]);
 				$freelist[$type][] = $key;
+				return $key;
 			}
-			return $key;
+
+			throw new \LogicException("attempted to delete non-existent record");
 		}
 
 		if($key === false) {


### PR DESCRIPTION
This speeds up array indices by 2-3x and keeps the arrays packed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the internal management of array-based IDs for better efficiency and reliability without changing any user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->